### PR TITLE
Distro names changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ We currently support these distributions:
 
 Also you can use distributions derived from up these. (Linux Mint, LMDE, Elementary, Pepper Mint, etc.)
 
+(Note: LMDE 17 (Jessie based) and Elementary OS Luna (Precise Pangolin based) passed the test.)
+
 # Use
 
 ### Mac OS X

--- a/linux.sh
+++ b/linux.sh
@@ -11,7 +11,7 @@ fancy_echo() {
 }
 
 ## Distro check
-if ! grep -qiE 'trusty|precise|wheezy|jessie' /etc/os-release
+if ! grep -qiE 'trusty|wheezy' /etc/os-release
 then
   fancy_echo "Sorry! we don't currently support that distro."
   exit 1


### PR DESCRIPTION
I have tested LMDE 17 (Jessie based) and Elementary OS Luna (Precise based). But I deleted distro names (Jessie and Precise). And it works. Also you can look [this issue](https://github.com/lab2023/builder/issues/7).
