### PR TITLE
Builder was updated. Look at the description for details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 ## Mac OS X
 
-1) Use [Command Line Tools for XCode](https://developer.apple.com/downloads/index.action) for Lion (OS X 10.7) or Mountain Lion (OS X 10.8).
+1) Install Xcode
 
-2) Set zsh as your login shell:
+2) Use [Command Line Tools for XCode](https://developer.apple.com/downloads/index.action) for Lion (OS X 10.7) or Mountain Lion (OS X 10.8) or Sierra.
+
+3) Set zsh as your login shell:
 
     chsh -s /bin/zsh
 

--- a/linux.sh
+++ b/linux.sh
@@ -108,7 +108,7 @@ fancy_echo "Installing Ruby dependencies ..."
   sudo aptitude install -y zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev
 
 ## Ruby environment
-RUBY_VERSION="2.3.5"
+RUBY_VERSION="2.5.0"
 
 fancy_echo "Preveting gem system from installing documentation ..."
   echo 'gem: --no-ri --no-doc' >> ~/.gemrc
@@ -124,7 +124,7 @@ fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
 
 fancy_echo "Installing Rails ..."
-  gem install rails -v '~> 5.1.4'
+  gem install rails
 
 fancy_echo "Installing PostgreSQL Ruby interface ..."
   gem install pg

--- a/mac.sh
+++ b/mac.sh
@@ -75,26 +75,24 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
 fancy_echo "Installing ruby-build, to install Rubies ..."
   brew install ruby-build
 
-## Compoler and libraries
-fancy_echo "Installing GNU Compiler Collection, a necessary prerequisite to installing Ruby ..."
-  brew tap homebrew/dupes
-  brew install apple-gcc42
-
 fancy_echo "Upgrading and linking OpenSSL ..."
   brew install openssl
 
 #export CC=gcc-4.2
 
 ## Ruby environment
-fancy_echo "Installing Ruby 2.3.5 ..."
-  rbenv install 2.3.5
+fancy_echo "Installing Ruby 2.5.0 ..."
+  rbenv install 2.5.0
 
-fancy_echo "Setting Ruby 2.3.5 as global default Ruby ..."
-  rbenv global 2.3.5
+fancy_echo "Setting Ruby 2.5.0 as global default Ruby ..."
+  rbenv global 2.5.0
   rbenv rehash
 
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
 
 fancy_echo "Installing critical Ruby gems for Rails development ..."
-  gem install bundler rails -v '~> 5.1.4'
+  gem install bundler rails
+
+fancy_echo "Installing postgresql..."
+  brew install postgresql


### PR DESCRIPTION
Update builder for rails and ruby version. homebrew/dupes removed because homebrew/dupes was merged with homebrew core. brew install apple-gcc42 was removed because Xcode was added into requirements after this apple-gcc42 is installing with Xcode. brew install postgresql was added into mac.sh .