### PR TITLE
Update for linux dependencies and newer ruby versions for all supported OS's.

### DIFF
--- a/archlinux.sh
+++ b/archlinux.sh
@@ -108,7 +108,7 @@ fancy_echo "Installing dependencies ..."
   install "cmake"
 
 ## Ruby environment
-RUBY_VERSION="2.5.1"
+RUBY_VERSION="3.1.0"
 
 fancy_echo "Preveting gem system from installing documentation ..."
   echo 'gem: --no-ri --no-doc' >> $HOME/.gemrc

--- a/linux.sh
+++ b/linux.sh
@@ -70,7 +70,7 @@ fancy_echo "Installing ImageMagick, to crop and resize images ..."
   sudo aptitude install -y imagemagick
 
 fancy_echo "Installing libraries for common gem dependencies ..."
-  sudo aptitude install -y libxslt1-dev libcurl4-openssl-dev libksba8 libksba-dev libqtwebkit-dev libreadline-dev libpq-dev
+  sudo aptitude install -y libxslt1-dev libcurl4-openssl-dev libksba8 libksba-dev libqt5webkit5-dev libreadline-dev libpq-dev
 
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
   sudo aptitude install -y watch
@@ -110,7 +110,7 @@ fancy_echo "Installing Ruby dependencies ..."
 ## Ruby environment
 RUBY_VERSION="3.1.0"
 
-fancy_echo "Preveting gem system from installing documentation ..."
+fancy_echo "Preventing gem system from installing documentation ..."
   echo 'gem: --no-ri --no-doc' >> ~/.gemrc
 
 fancy_echo "Installing Ruby $RUBY_VERSION ..."

--- a/mac.sh
+++ b/mac.sh
@@ -81,11 +81,11 @@ fancy_echo "Upgrading and linking OpenSSL ..."
 #export CC=gcc-4.2
 
 ## Ruby environment
-fancy_echo "Installing Ruby 2.5.1 ..."
-  rbenv install 2.5.1
+fancy_echo "Installing Ruby 3.1.0 ..."
+  rbenv install 3.1.0
 
-fancy_echo "Setting Ruby 2.5.1 as global default Ruby ..."
-  rbenv global 2.5.1
+fancy_echo "Setting Ruby 3.1.0 as global default Ruby ..."
+  rbenv global 3.1.0
   rbenv rehash
 
 fancy_echo "Updating to latest Rubygems version ..."


### PR DESCRIPTION
Corrupted Linux dependencies are reviewed and fixed (libqtwebkit-dev wasn't supported by latest Ubuntu version which is 20.04-Focal Fossa. Instead libqt5webkit5-dev added.

Archlinux, Mac Operating Systems was installing 2.7.0 via builder so script is updated to install latest stable version.

Some typos are fixed.